### PR TITLE
fix: remove omitempty options

### DIFF
--- a/pagecall/member.go
+++ b/pagecall/member.go
@@ -14,8 +14,8 @@ type inlineSession struct {
 	ApplicationID        string `json:"application_id"`
 	ConnectionID         string `json:"connection_id"`
 	ConnectedAt          string `json:"connected_at"`
-	StartUsingCanvasAt   string `json:"start_using_canvas_at,omitempty"`
-	DisconnectedAt       string `json:"disconnected_at,omitempty"`
+	StartUsingCanvasAt   string `json:"start_using_canvas_at"`
+	DisconnectedAt       string `json:"disconnected_at"`
 	LastPingedAt         string `json:"last_pinged_at"`
 	ElaspsedTime         int    `json:"elapsed_time"`
 	SubscribedCanvasTime int    `json:"subscribed_canvas_time"`
@@ -38,7 +38,7 @@ type member struct {
 	Options        map[string]interface{} `json:"options"`
 	CreatedAt      string                 `json:"created_at"`
 	UpdatedAt      string                 `json:"updated_at"`
-	Sessions       []inlineSession        `json:"sessions,omitempty"`
+	Sessions       []inlineSession        `json:"sessions"`
 }
 
 func (p pageCallClient) GetMembers(roomID string, offset int, limit int) ([]member, error) {

--- a/pagecall/room.go
+++ b/pagecall/room.go
@@ -16,10 +16,10 @@ type room struct {
 	IsDistinct               bool     `json:"is_distinct"`
 	ThumbnailURL             string   `json:"thumbnail_url"`
 	LiveTime                 int      `json:"live_time"`
-	LiveTimeSectionStartedAt string   `json:"live_time_section_started_at,omitempty"`
+	LiveTimeSectionStartedAt string   `json:"live_time_section_started_at"`
 	IsRecurring              bool     `json:"is_recurring"`
 	IsTerminated             bool     `json:"is_terminated"`
-	TerminatedAt             string   `json:"terminated_at,omitempty"`
+	TerminatedAt             string   `json:"terminated_at"`
 	CreatedAt                string   `json:"created_at"`
 	UpdatedAt                string   `json:"updated_at"`
 	DistinctUserIDs          []string `json:"distinct_user_ids"`


### PR DESCRIPTION
## 변경 사항
- 기존에는 API 응답 json 파싱 시, 상황에 따라 존재하지 않는 속성들은 omitempty 처리를 해주었습니다.
- 그러나 API 일관성을 위해, omitempty 대신 빈 값을 반환하는 것으로 변경하였습니다.